### PR TITLE
Add rubocop-github

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -53,6 +53,7 @@ def installAll(rubocopVersion: String) =
      |&& gem install rubocop-migrations:0.1.2
      |&& gem install rubocop-rspec:1.20.1
      |&& gem install lingohub-rubocop:1.0.3
+     |&& gem install rubocop-github:0.10.0
      |&& gem install safe_yaml
      |&& gem cleanup
      |&& rm -rf /tmp/* /var/cache/apk/*""".stripMargin.replaceAll(System.lineSeparator(), " ")


### PR DESCRIPTION
This repository provides recommended RuboCop configuration and additional Cops for use on GitHub open source and internal Ruby projects. (This serves as a good ruleset for use in any Ruby/Rails projects)