### PR TITLE
Update dark_finger version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GEM
     ast (2.4.0)
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
-    dark_finger (0.5.0)
+    dark_finger (0.5.1)
       rubocop (>= 0.51.0)
     i18n (1.1.0)
       concurrent-ruby (~> 1.0)


### PR DESCRIPTION
Updating dark finger as the version had bumped which should resolve this error.

```
Rubocop exited with code 2
stdout: 
stderr: uninitialized constant RuboCop::Cop::DarkFinger::SimpleDelegator
/usr/lib/ruby/gems/2.4.0/gems/dark_finger-0.5.0/lib/rubocop/cop/dark_finger/active_model_node_decorator.rb:4:in `<module:DarkFinger>'
```