### PR TITLE
fix: Add graphql to be available to be referenced CY-5814

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,8 @@ gem "safe_yaml"
 gem "dark_finger"
 gem "rubocop-migrations"
 gem "rubocop", "1.26.0"
+#Needed to be referenced on some user configs
+gem "graphql"
 #Rubocop official modules
 gem "rubocop-performance"
 gem "rubocop-rails"

--- a/docs/multiple-tests/with-config-file/src/.rubocop.yml
+++ b/docs/multiple-tests/with-config-file/src/.rubocop.yml
@@ -1,6 +1,8 @@
 require:
   - rubocop-performance
   - rubocop-rails
+  - graphql/rubocop/graphql/default_null_true
+  - graphql/rubocop/graphql/default_required_true
 
 AllCops:
   Exclude:


### PR DESCRIPTION
This will avoid that tool crashes when a graphql rule is referenced
directly by the file location

This fixes #300 