### PR TITLE
security: Delay dependabot updates [TAROT-3707]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,22 +1,24 @@
 version: 2
 updates:
-- package-ecosystem: bundler
-  directory: "/"
-  schedule:
-    interval: daily
-    timezone: Europe/Lisbon
-  open-pull-requests-limit: 10
-  allow:
-  - dependency-type: direct
-  - dependency-type: indirect
-  ignore:
-  - dependency-name: i18n
-    versions:
-    - 1.8.10
-    - 1.8.8
-  - dependency-name: ast
-    versions:
-    - 2.4.2
-  - dependency-name: concurrent-ruby
-    versions:
-    - 1.1.8
+  - package-ecosystem: bundler
+    directory: "/"
+    schedule:
+      interval: daily
+      timezone: Europe/Lisbon
+    open-pull-requests-limit: 10
+    allow:
+      - dependency-type: direct
+      - dependency-type: indirect
+    ignore:
+      - dependency-name: i18n
+        versions:
+          - 1.8.10
+          - 1.8.8
+      - dependency-name: ast
+        versions:
+          - 2.4.2
+      - dependency-name: concurrent-ruby
+        versions:
+          - 1.1.8
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
7 days should be enough when most malicious packages are patched within 24 hours.